### PR TITLE
Fix: fallback pentru selectorul backgroundIcons la creare board

### DIFF
--- a/src/redux/board/boardOperations.js
+++ b/src/redux/board/boardOperations.js
@@ -8,7 +8,7 @@ export const getBackgroundIcons = createAsyncThunk(
   async (_, thunkAPI) => {
     try {
       const { data } = await axiosInstance.get(ENDPOINTS.backgrounds);
-      return data;
+      return data.backgrounds;
     } catch (error) {
       return thunkAPI.rejectWithValue(error.message);
     }

--- a/src/redux/board/boardSelectors.js
+++ b/src/redux/board/boardSelectors.js
@@ -1,4 +1,4 @@
-export const selectBackgroundIcons = state => state.boards.background;
+export const selectBackgroundIcons = state => state.boards.background || [];
 export const selectBoards = state => state.boards.boards;
 export const selectIsLoading = state => state.boards.isLoading;
 export const selectOneBoard = state => state.boards.oneBoard;


### PR DESCRIPTION
Descriere PR:
Am adăugat un fallback (|| []) în selectorul selectBackgroundIcons din boardSelectors.js pentru a preveni erorile de tip map is not a function, apărute în momentul în care se creează un board nou și reducerul încă nu a populat state.boards.background.